### PR TITLE
Fixed ruby version and dependency package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # gollum-blueprint
 
-DESCRIPTION
+### DESCRIPTION
 
 Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a git repository of a specific nature:
-
-A Gollum repository's contents are human-editable text or markup files.
-Pages may be organized into directories any way you choose.
-Other content can also be included, for example images, PDFs and headers/footers for your pages.
-Gollum pages:
-May be written in a variety of markups.
-Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
-Can be displayed in all versions, reverted, etc.
-Gollum strives to be compatible with GitHub wikis
+* A Gollum repository's contents are human-editable text or markup files.
+* Pages may be organized into directories any way you choose.
+* Other content can also be included, for example images, PDFs and headers/footers for your pages.
+* Gollum pages:
+	* May be written in a variety of [markups](#markups).
+	* Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
+	* Can be displayed in all versions, reverted, etc.
+* Gollum strives to be compatible with GitHub wikis 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gollum-blueprint
 
 DESCRIPTION
+
 Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a git repository of a specific nature:
 
 A Gollum repository's contents are human-editable text or markup files.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # gollum-blueprint
+
+DESCRIPTION
+Gollum is a simple wiki system built on top of Git. A Gollum Wiki is simply a git repository of a specific nature:
+
+A Gollum repository's contents are human-editable text or markup files.
+Pages may be organized into directories any way you choose.
+Other content can also be included, for example images, PDFs and headers/footers for your pages.
+Gollum pages:
+May be written in a variety of markups.
+Can be edited with your favourite system editor or IDE (changes will be visible after committing) or with the built-in web interface.
+Can be displayed in all versions, reverted, etc.
+Gollum strives to be compatible with GitHub wikis

--- a/Subutai.json
+++ b/Subutai.json
@@ -1,7 +1,7 @@
 {
     "name": "${environmentName}",
     "description": "h",
-    "version": "4.1.2",
+    "version": "5.0.1",
     "author": "https://github.com/happyaron",
     "containers": [
         {

--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,13 @@
 - hosts: all
   gather_facts: false
   remote_user: root
-  tasks: 
+  tasks:
+  
+    - name: Upgrade debian
+      apt:
+        update_cache: true
+        upgrade: true
+
     - name: Install tools
       apt:
         name: "{{ item }}"
@@ -12,8 +18,8 @@
         update_cache: yes
         dpkg_options: force-confdef,force-confold,force-unsafe-io
       with_items: 
-        - ruby
-        - ruby-dev
+        - wget
+        - xz-utils
         - make
         - zlib1g-dev
         - libicu-dev
@@ -21,7 +27,37 @@
         - git
         - nginx
         - ca-certificates
+        - cmake
+        - libssl-dev
+        - pkg-config
 
+    - name: Extract Ruby 2.7.1 into /tmp
+      unarchive:
+        src: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.xz
+        dest: /tmp/
+        remote_src: yes
+        
+    - name: Configure Ruby 2.7.1
+      shell: ./configure chdir=/tmp/ruby-2.7.1
+      tags: packages, ruby
+        
+    - name: Make
+      shell: make chdir=/tmp/ruby-2.7.1
+      tags: packages, ruby
+        
+    - name: Install Ruby 2.7.1
+      shell: make install chdir=/tmp/ruby-2.7.1
+      become: yes
+      become_user: root
+      tags: packages, ruby
+      
+    - name: Remove tmp files used for Ruby 2.7.1 installation
+      file: path={{ item }} state=absent
+      with_items:
+        - /tmp/ruby-2.7.1.tar.xz
+        - /tmp/ruby-2.7.1
+      tags: packages, ruby   
+      
     - name: Install Gollum
       gem:
         name: "{{ item }}"


### PR DESCRIPTION
Gollum-lib requires Ruby 2.4.0+
https://github.com/gollum/gollum-lib